### PR TITLE
Steps added for setting up v26

### DIFF
--- a/TestGuides/27.0-Release-Candidate-Testing-Guide.md
+++ b/TestGuides/27.0-Release-Candidate-Testing-Guide.md
@@ -27,13 +27,20 @@ For a comprehensive list of changes in Bitcoin Core 27.0, check out the [release
 
 ## Preparation
 
-### 1. Grab Latest Release Candidate
+### 1. Obtain Latest Release Candidate
 
 **Current Release Candidate:** [Bitcoin Core 27.0rc1][source-code] ([release-notes][release notes])
 
 There are two ways to grab the latest release candidate: pre-compiled binary or source code. The source code for the latest release can be obtained here: [latest release source code][source-code]
       
 If you prefer to use a binary, make sure to [grab the correct one for your system][binaries].
+When working from binary, extract (example for x86_64):
+```bash
+cd
+wget https://bitcoincore.org/bin/bitcoin-core-27.0/test.rc1/bitcoin-27.0rc1-x86_64-linux-gnu.tar.gz
+tar xf bitcoin-27.0rc1-x86_64-linux-gnu.tar.gz
+```
+(directory `~/bitcoin-27.0rc1/` now exists containing binaries)
 
 [source-code]: https://github.com/bitcoin/bitcoin/releases/tag/v27.0rc1
 [binaries]: https://bitcoincore.org/bin/bitcoin-core-27.0/test.rc1/
@@ -46,6 +53,7 @@ If you prefer to use a binary, make sure to [grab the correct one for your syste
 Before compiling, make sure that your system has all the correct [dependencies][dependencies] installed and that you have checked out the correct tag:
 
 ```shell
+cd
 git checkout -b v27.0r1 tags/v27.0rc1
 ```
 
@@ -53,91 +61,150 @@ For more information on compiling from source, here are some guides to compile B
 
 [dependencies]: https://github.com/bitcoin/bitcoin/blob/master/doc/dependencies.md
 
-### 3. Setting up command line environment
+### 3. Obtain Previous Release
 
-First, create a temporary data directory
+Some testing involves using the previous release, v26.0.
+Obtain the binary from [here][binaries26] and extract to a known location:
+```bash
+cd
+wget wget https://bitcoincore.org/bin/bitcoin-core-26.0/bitcoin-26.0-x86_64-linux-gnu.tar.gz
+tar xf bitcoin-26.0-x86_64-linux-gnu.tar.gz
+```
+(directory `~/bitcoin-26.0` now exists containing binaries)
+
+[binaries26]: https://bitcoincore.org/bin/bitcoin-core-26.0/
+
+
+### 4. Setting up command line environment
+
+First, create temporary data directories
 ```shell
 export DATA_DIR=/tmp/27-rc-test
 mkdir $DATA_DIR
+export DATA_DIR_26=/tmp/26-test
+mkdir $DATA_DIR_26
 ```
 
 Next, specify the following paths. 
-If testing from source compiled source, start from the root of your release candidate directory and run:
+If testing from v27 source compiled source, start from the root of your release candidate directory and run:
 
 ```shell
+cd ~/bitcoin
 export BINARY_PATH=$(pwd)/src
 ```
 
-If testing from downloaded binary, start from the root of the downloaded release candidate (cd ~/bitcoin-27.0rc1, for example) and run:
+If testing from v27 downloaded binary, start from the root of the downloaded release candidate (cd ~/bitcoin-27.0rc1, for example) and run:
 ```shell
+cd ~/bitcoin-27.0rc1
 export BINARY_PATH=$(pwd)/bin
 ```
+
+Specify the binary path for the v26 binary, starting from the root of the downloaded v26 release.
+```shell
+cd ~/bitcoin-26.0
+export BINARY_PATH_26=$(pwd)/bin
 
 To avoid specifying the data directory (`-datadir=$DATA_DIR`) on each command, below are a few extra variables to set.
 ```shell
 alias bitcoind-test="$(echo $BINARY_PATH)/bitcoind -datadir=$DATA_DIR"
 alias bcli="$(echo $BINARY_PATH)/bitcoin-cli -datadir=$DATA_DIR"
+alias bitcoind-test-26="$(echo $BINARY_PATH_26)/bitcoind -datadir=$DATA_DIR_26"
+alias bcli26="$(echo $BINARY_PATH_26)/bitcoin-cli -datadir=$DATA_DIR_26"
 ```
 
-Once you have set up the test aliases used throughout the rest of this guide,
-you can verify that they are pointing to the correct binaries by running:
+Prepare a basic bitcoin.conf file for each version.
+For 27:
+```bash
+echo "regtest=1" > $DATA_DIR/bitcoin.conf
+```
 
+For 26:
+```bash
+echo "regtest=1" > $DATA_DIR_26/bitcoin.conf
+echo "[regtest]" >> $DATA_DIR_26/bitcoin.conf
+echo "rpcallowip=127.0.0.1" >> $DATA_DIR_26/bitcoin.conf
+echo "rpcbind=127.0.0.1:48443" >> $DATA_DIR_26/bitcoin.conf
+echo "bind=127.0.0.1:48444" >> $DATA_DIR_26/bitcoin.conf
+echo "bind=127.0.0.1:48445=onion" >> $DATA_DIR_26/bitcoin.conf
+```
+
+
+Verify that the aliases are pointing to the correct binaries:
+
+Verify v27.0 RC:
 ```bash
 bcli --version
-bitcoind-teset --version
+bitcoind-test --version
+```
+Expected:
+```
+Bitcoin Core RPC client version v27.0.0rc1
+Bitcoin Core version v27.0.0rc1
 ```
 
-and verifying that both report `Bitcoin Core version v27.0rc1`.
+Also verify v26.0:
+```bash
+bcli26 --version
+bitcoind-test-26 --version
+```
+
+Expected:
+```
+Bitcoin Core RPC client version v26.0.0
+Bitcoin Core version v26.0.0
+```
 
 
-The commands throughout the rest of the guide will look like:
+The commands throughout the rest of the guide will look similar to the following
 
+When using RPC:
 ```shell
 bcli [cli args]
 ```
 
-**Start node**
-```shell
-echo "regtest=1" > $DATA_DIR/bitcoin.conf
-```
-
+When starting a node:
 ```shell
 bitcoind-test
 ```
 
 ```shell
-2024-03-10T22:05:26Z Bitcoin Core version TODO: UPDATE THIS VERSION
-2024-03-10T22:05:26Z Script verification uses 9 additional threads
-2024-03-10T22:05:26Z Using the 'standard' SHA256 implementation
-2024-03-10T22:05:26Z Default data directory /home/[USER]/.bitcoin
-2024-03-10T22:05:26Z Using data directory /tmp/27-rc-test/regtest
-2024-03-10T22:05:26Z Config file: /tmp/27-rc-test/bitcoin.conf
-2024-03-10T22:05:26Z Config file arg: regtest="1"
-2024-03-10T22:05:26Z Command-line arg: datadir="/tmp/27-rc-test"
+2024-03-17T01:56:57Z Bitcoin Core version v27.0.0rc1 (release build)
+2024-03-17T01:56:57Z Script verification uses 15 additional threads
+2024-03-17T01:56:57Z Using the 'standard' SHA256 implementation
+2024-03-17T01:56:57Z Default data directory /home/dev/.bitcoin
+2024-03-17T01:56:57Z Using data directory /tmp/27-rc-test/regtest
+2024-03-17T01:56:57Z Config file: /tmp/27-rc-test/bitcoin.conf
+2024-03-17T01:56:57Z Config file arg: regtest="1"
+2024-03-17T01:56:57Z Command-line arg: datadir="/tmp/27-rc-test"
 ```
-TODO:  UPDATE SHELL OUTPUT
-Stop bitcoind
+
+To stop the node
 ```shell
 Ctrl + C
 ```
-Inspect the ouput and ensure Release Candidate 27.0r1 was running.
+Perform a start and stop on each node (v27 and v26), and inspect the ouput for the correct version.
 
 For the rest of the guide bitcoind will be started in daemon mode (`-daemon`) and as such `CTRL + C` will not stop the process. Instead, use `bcli stop`.
 
-### 4. Reset testing environment
+### 5. Reset testing environment
 
 Between sections in this guide, it's recommended to stop your node and wipe the data directory. You can use the commands provided below.
 
 **Stop node**
 ```shell
 bcli stop
+bcli26 stop
 ```
 
-**Wipe and recreate the directory**
+**Wipe**
 ```shell
 rm -r $DATA_DIR
 mkdir $DATA_DIR
+rm -r $DATA_DIR_26
+mkdir $DATA_DIR_26
 ```
+
+**Recreate the bitcoin.conf files as shown above**
 
 ***
 


### PR DESCRIPTION
Steps were added to set up a v26 node.  Non-conflicting ports were chosen for the v26 bitcoin.conf.