### PR TITLE
Remove bitcoin/bitcoin prefix + remove superfluous word.

### DIFF
--- a/TestGuides/27.0-Release-Candidate-Testing-Guide.md
+++ b/TestGuides/27.0-Release-Candidate-Testing-Guide.md
@@ -11,14 +11,14 @@ This can be as simple as testing the same features in this guide but trying it a
 
 Changes covered in this testing guide include:
 
-* [Mempool.dat v1/v2 compatibility](#mempooldat-v1v2-compatibility) ([bitcoin/bitcoin#28207](https://github.com/bitcoin/bitcoin/pull/28207))
-* [v2 Transport on by default](#v2-transport-on-by-default) ([bitcoin/bitcoin#29347](https://github.com/bitcoin/bitcoin/pull/29347))
-* [`-netinfo` backward compatibility with pre-v26 nodes](#netinfo-backward-compatibility-with-pre-v26-nodes) ([bitcoin/bitcoin#29212](https://github.com/bitcoin/bitcoin/pull/29212))
-* [v3 Transaction Policy](#v3-transaction-policy) ([bitcoin/bitcoin#28948](https://github.com/bitcoin/bitcoin/pull/29347))
+* [Mempool.dat v1/v2 compatibility](#mempooldat-v1v2-compatibility) ([#28207](https://github.com/bitcoin/bitcoin/pull/28207))
+* [v2 Transport on by default](#v2-transport-on-by-default) ([#29347](https://github.com/bitcoin/bitcoin/pull/29347))
+* [`-netinfo` backward compatibility with pre-v26 nodes](#netinfo-backward-compatibility-with-pre-v26-nodes) ([#29212](https://github.com/bitcoin/bitcoin/pull/29212))
+* [v3 Transaction Policy](#v3-transaction-policy) ([#28948](https://github.com/bitcoin/bitcoin/pull/29347))
 * [CoinGrinder coin selection algorithm](#coingrinder-coin-selection-algorithm)
-  ([bitcoin/bitcoin#27877](https://github.com/bitcoin/bitcoin/pull/27877))
+  ([#27877](https://github.com/bitcoin/bitcoin/pull/27877))
 * [`migratewallet` RPC is no longer experimental](#migratewallet-rpc-is-no-longer-experimental)
-  ([bitcoin/bitcoin#28037](https://github.com/bitcoin/bitcoin/pull/29347))
+  ([#28037](https://github.com/bitcoin/bitcoin/pull/29347))
 
 ***
 
@@ -251,7 +251,7 @@ Recreate the bitcoin.conf files as specified in [Create Configuration Files](#Cr
 ***
 
 ## mempool.dat v1/v2 compatibility
-The `mempool.dat` file created uses a new format (v2, enhancing integrity checking of `mempool.dat`), which isn't understood by previous versions of Bitcoin Core.  A temporary setting `-persistmempoolv1` allows fallback to the legacy format.
+The `mempool.dat` file uses a new format (v2, enhancing integrity checking of `mempool.dat`), which isn't understood by previous versions of Bitcoin Core.  A temporary setting `-persistmempoolv1` allows fallback to the legacy format.
 
 The following tests migration from the legacy v1 to the new v2 format.
 


### PR DESCRIPTION
I'll let someone else merge this if they agree.